### PR TITLE
Hotfix: panic in contentType.

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -34,10 +34,10 @@ func extFromContentType(ct string) string {
 
 func contentType(u *url.URL) string {
 	resp, err := http.Head(u.String())
-	defer resp.Body.Close()
 	if err != nil {
 		return "application/octet-stream"
 	}
+	defer resp.Body.Close()
 	return resp.Header.Get("Content-Type")
 }
 


### PR DESCRIPTION
resp.Body will be null in most error cases.
